### PR TITLE
Revert "Name of aks cluster should be from cluster object and not amcp object."

### DIFF
--- a/exp/controllers/azuremangedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremangedcontrolplane_reconciler.go
@@ -73,7 +73,7 @@ func (r *azureManagedControlPlaneReconciler) Reconcile(ctx context.Context, scop
 	}
 
 	managedClusterSpec := &managedclusters.Spec{
-		Name:                  scope.Cluster.Name,
+		Name:                  scope.ControlPlane.Name,
 		ResourceGroupName:     scope.ControlPlane.Spec.ResourceGroupName,
 		NodeResourceGroupName: scope.ControlPlane.Spec.NodeResourceGroupName,
 		Location:              scope.ControlPlane.Spec.Location,


### PR DESCRIPTION
Reverts spectrocloud/cluster-api-provider-azure#8