### PR TITLE
v1alpha3 system node pool

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -153,20 +153,6 @@ def capz():
         deps = ["api", "cloud", "config", "controllers", "exp", "feature", "pkg", "go.mod", "go.sum", "main.go"]
     )
 
-    k8s_resource('capz-controller-manager:deployment:capz-system', objects=[
-        'azureclusters.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-        'azuremachinepools.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-        'azuremachines.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-        'azuremachinetemplates.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-        'azuremanagedclusters.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-        'azuremanagedcontrolplanes.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-        'azuremanagedmachinepools.exp.infrastructure.cluster.x-k8s.io:customresourcedefinition',
-    ])
-
-    k8s_resource('capz-controller-manager:deployment:capi-webhook-system', objects=[
-        'capz-validating-webhook-configuration:validatingwebhookconfiguration',
-        'capz-mutating-webhook-configuration:mutatingwebhookconfiguration',
-    ])
 
     dockerfile_contents = "\n".join([
         tilt_helper_dockerfile_header,

--- a/cloud/services/agentpools/agentpools.go
+++ b/cloud/services/agentpools/agentpools.go
@@ -38,6 +38,7 @@ type Spec struct {
 	Replicas      int32
 	OSDiskSizeGB  int32
 	VnetSubnetID  string
+	Mode          string
 }
 
 // Reconcile idempotently creates or updates a agent pool, if possible.
@@ -59,6 +60,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			Type:                containerservice.AgentPoolTypeVirtualMachineScaleSets,
 			OrchestratorVersion: agentPoolSpec.Version,
 			VnetSubnetID:        &agentPoolSpec.VnetSubnetID,
+			Mode:                containerservice.AgentPoolMode(agentPoolSpec.Mode),
 		},
 	}
 
@@ -89,6 +91,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 				Count:               existingPool.ManagedClusterAgentPoolProfileProperties.Count,
 				OrchestratorVersion: existingPool.ManagedClusterAgentPoolProfileProperties.OrchestratorVersion,
+				Mode:                existingPool.Mode,
 			},
 		}
 
@@ -96,6 +99,7 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 			ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
 				Count:               profile.Count,
 				OrchestratorVersion: profile.OrchestratorVersion,
+				Mode:                profile.Mode,
 			},
 		}
 
@@ -103,7 +107,6 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		diff := cmp.Diff(normalizedProfile, existingProfile)
 		if diff != "" {
 			klog.V(2).Infof("Update required (+new -old):\n%s", diff)
-			profile.Mode = existingPool.Mode
 			err = s.Client.CreateOrUpdate(ctx, agentPoolSpec.ResourceGroup, agentPoolSpec.Cluster, agentPoolSpec.Name, profile)
 			if err != nil {
 				return errors.Wrap(err, "failed to create or update agent pool")

--- a/cloud/services/bastionhosts/mocks_bastionhosts/client_mock.go
+++ b/cloud/services/bastionhosts/mocks_bastionhosts/client_mock.go
@@ -22,10 +22,9 @@ package mock_bastionhosts
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // Mockclient is a mock of client interface.

--- a/cloud/services/inboundnatrules/mock_inboundnatrules/client_mock.go
+++ b/cloud/services/inboundnatrules/mock_inboundnatrules/client_mock.go
@@ -22,10 +22,9 @@ package mock_inboundnatrules
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // Mockclient is a mock of client interface.

--- a/cloud/services/loadbalancers/mock_loadbalancers/client_mock.go
+++ b/cloud/services/loadbalancers/mock_loadbalancers/client_mock.go
@@ -22,10 +22,9 @@ package mock_loadbalancers
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface.

--- a/cloud/services/managedclusters/managedclusters.go
+++ b/cloud/services/managedclusters/managedclusters.go
@@ -204,7 +204,8 @@ func (s *Service) Reconcile(ctx context.Context, spec interface{}) error {
 		}
 	}
 
-	for _, pool := range managedClusterSpec.AgentPools {
+	for i := range managedClusterSpec.AgentPools {
+		pool := managedClusterSpec.AgentPools[i]
 		profile := containerservice.ManagedClusterAgentPoolProfile{
 			Name:         &pool.Name,
 			VMSize:       &pool.SKU,

--- a/cloud/services/networkinterfaces/mock_networkinterfaces/client_mock.go
+++ b/cloud/services/networkinterfaces/mock_networkinterfaces/client_mock.go
@@ -22,10 +22,9 @@ package mock_networkinterfaces
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface.

--- a/cloud/services/publicips/mock_publicips/client_mock.go
+++ b/cloud/services/publicips/mock_publicips/client_mock.go
@@ -22,10 +22,9 @@ package mock_publicips
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface.

--- a/cloud/services/routetables/mock_routetables/client_mock.go
+++ b/cloud/services/routetables/mock_routetables/client_mock.go
@@ -22,10 +22,9 @@ package mock_routetables
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // Mockclient is a mock of client interface.

--- a/cloud/services/securitygroups/mock_securitygroups/client_mock.go
+++ b/cloud/services/securitygroups/mock_securitygroups/client_mock.go
@@ -22,10 +22,9 @@ package mock_securitygroups
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // Mockclient is a mock of client interface.

--- a/cloud/services/subnets/mock_subnets/client_mock.go
+++ b/cloud/services/subnets/mock_subnets/client_mock.go
@@ -22,10 +22,9 @@ package mock_subnets
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface.

--- a/cloud/services/virtualnetworks/mock_virtualnetworks/client_mock.go
+++ b/cloud/services/virtualnetworks/mock_virtualnetworks/client_mock.go
@@ -22,10 +22,9 @@ package mock_virtualnetworks
 
 import (
 	context "context"
-	reflect "reflect"
-
 	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockClient is a mock of Client interface.

--- a/cloud/services/virtualnetworks/virtualnetworks.go
+++ b/cloud/services/virtualnetworks/virtualnetworks.go
@@ -113,15 +113,13 @@ func (s *Service) Delete(ctx context.Context) error {
 	defer span.End()
 
 	vnetSpec := s.Scope.VNetSpec()
-	existingVnet, err := s.getExisting(ctx, vnetSpec)
-
-	if !existingVnet.IsManaged(s.Scope.ClusterName()) {
+	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping VNet deletion in custom vnet mode")
 		return nil
 	}
 
 	s.Scope.V(2).Info("deleting VNet", "VNet", vnetSpec.Name)
-	err = s.Client.Delete(ctx, vnetSpec.ResourceGroup, vnetSpec.Name)
+	err := s.Client.Delete(ctx, vnetSpec.ResourceGroup, vnetSpec.Name)
 	if err != nil {
 		if azure.ResourceGroupNotFound(err) || azure.ResourceNotFound(err) {
 			return nil

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedcontrolplanes.yaml
@@ -109,15 +109,6 @@ spec:
                 - host
                 - port
                 type: object
-              defaultPoolRef:
-                description: DefaultPoolRef is the specification for the default pool,
-                  without which an AKS cluster cannot be created.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               dnsServiceIP:
                 description: DNSServiceIP is an IP address assigned to the Kubernetes
                   DNS service. It must be within the Kubernetes service address range
@@ -192,7 +183,6 @@ spec:
                 - name
                 type: object
             required:
-            - defaultPoolRef
             - location
             - nodeResourceGroupName
             - resourceGroupName

--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_azuremanagedmachinepools.yaml
@@ -42,6 +42,13 @@ spec:
             description: AzureManagedMachinePoolSpec defines the desired state of
               AzureManagedMachinePool
             properties:
+              mode:
+                description: 'Mode - represents mode of an agent pool. Possible values
+                  include: System, User.'
+                enum:
+                - System
+                - User
+                type: string
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this
                   agent pool. If you specify 0, it will apply the default osDisk size
@@ -58,6 +65,8 @@ spec:
                 description: SKU is the size of the VMs in the node pool.
                 type: string
             required:
+            - mode
+            - osDiskSizeGB
             - sku
             type: object
           status:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -3,6 +3,8 @@ namespace: capi-webhook-system
 resources:
   - manifests.yaml
   - service.yaml
+  - role.yaml
+  - role_binding.yaml
   - ../certmanager
   - ../manager
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -83,6 +83,24 @@ webhooks:
     - UPDATE
     resources:
     - azuremanagedcontrolplanes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool
+  failurePolicy: Fail
+  name: azuremanagedmachinepool.kb.io
+  rules:
+  - apiGroups:
+    - exp.infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azuremanagedmachinepools
 
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
@@ -168,3 +186,21 @@ webhooks:
     - UPDATE
     resources:
     - azuremanagedcontrolplanes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool
+  failurePolicy: Fail
+  name: azuremanagedmachinepool.kb.io
+  rules:
+  - apiGroups:
+    - exp.infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - azuremanagedmachinepools

--- a/config/webhook/role.yaml
+++ b/config/webhook/role.yaml
@@ -1,0 +1,227 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: manager-role-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aadpodidentity.k8s.io
+  resources:
+  - azureidentities
+  - azureidentities/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aadpodidentity.k8s.io
+  resources:
+  - azureidentitybindings
+  - azureidentitybindings/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - exp.cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedcontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedmachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedmachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusteridentities
+  - azureclusteridentities/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachinetemplates
+  - azuremachinetemplates/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/webhook/role_binding.yaml
+++ b/config/webhook/role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role-webhook
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: system

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
@@ -68,9 +67,6 @@ type AzureManagedControlPlaneSpec struct {
 
 	// SSHPublicKey is a string literal containing an ssh public key base64 encoded.
 	SSHPublicKey string `json:"sshPublicKey"`
-
-	// DefaultPoolRef is the specification for the default pool, without which an AKS cluster cannot be created.
-	DefaultPoolRef corev1.LocalObjectReference `json:"defaultPoolRef"`
 
 	// DNSServiceIP is an IP address assigned to the Kubernetes DNS service.
 	// It must be within the Kubernetes service address range specified in serviceCidr.

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_webhook.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_webhook.go
@@ -218,16 +218,6 @@ func (r *AzureManagedControlPlane) ValidateUpdate(oldRaw runtime.Object) error {
 		}
 	}
 
-	if old.Spec.DefaultPoolRef.Name != "" {
-		if r.Spec.DefaultPoolRef.Name != old.Spec.DefaultPoolRef.Name {
-			allErrs = append(allErrs,
-				field.Invalid(
-					field.NewPath("Spec", "DefaultPoolRef", "Name"),
-					r.Spec.DefaultPoolRef.Name,
-					"field is immutable"))
-		}
-	}
-
 	errs := r.validateUpdateAadProfile(old.Spec.AADProfile)
 	allErrs = append(allErrs, errs...)
 

--- a/exp/api/v1alpha3/azuremanagedcontrolplane_webhook_test.go
+++ b/exp/api/v1alpha3/azuremanagedcontrolplane_webhook_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	. "github.com/onsi/gomega"
 
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -598,28 +597,6 @@ func TestAzureManagedControlPlane_ValidateUpdate(t *testing.T) {
 			},
 			amcp: &AzureManagedControlPlane{
 				Spec: AzureManagedControlPlaneSpec{
-					DNSServiceIP: to.StringPtr("192.168.0.0"),
-					Version:      "v1.18.0",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "AzureManagedControlPlane DefaultPoolRef.Name is immutable",
-			oldAMCP: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					DefaultPoolRef: v1.LocalObjectReference{
-						Name: "pool-1",
-					},
-					DNSServiceIP: to.StringPtr("192.168.0.0"),
-					Version:      "v1.18.0",
-				},
-			},
-			amcp: &AzureManagedControlPlane{
-				Spec: AzureManagedControlPlaneSpec{
-					DefaultPoolRef: v1.LocalObjectReference{
-						Name: "pool-2",
-					},
 					DNSServiceIP: to.StringPtr("192.168.0.0"),
 					Version:      "v1.18.0",
 				},

--- a/exp/api/v1alpha3/azuremanagedmachinepool_types.go
+++ b/exp/api/v1alpha3/azuremanagedmachinepool_types.go
@@ -21,14 +21,33 @@ import (
 	capierrors "sigs.k8s.io/cluster-api/errors"
 )
 
+const (
+	// LabelAgentPoolMode represents mode of an agent pool. Possible values include: System, User.
+	LabelAgentPoolMode = "azuremanagedmachinepool.infrastructure.cluster.x-k8s.io/agentpoolmode"
+
+	// NodePoolModeSystem represents mode system for azuremachinepool.
+	NodePoolModeSystem NodePoolMode = "System"
+
+	// NodePoolModeUser represents mode user for azuremachinepool.
+	NodePoolModeUser NodePoolMode = "User"
+)
+
+// NodePoolMode enumerates the values for agent pool mode.
+type NodePoolMode string
+
 // AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool
 type AzureManagedMachinePoolSpec struct {
+
+	// Mode - represents mode of an agent pool. Possible values include: System, User.
+	// +kubebuilder:validation:Enum=System;User
+	Mode string `json:"mode"`
+
 	// SKU is the size of the VMs in the node pool.
 	SKU string `json:"sku"`
 
 	// OSDiskSizeGB is the disk size for every machine in this agent pool.
 	// If you specify 0, it will apply the default osDisk size according to the vmSize specified.
-	OSDiskSizeGB *int32 `json:"osDiskSizeGB,omitempty"`
+	OSDiskSizeGB *int32 `json:"osDiskSizeGB"`
 
 	// ProviderIDList is the unique identifier as specified by the cloud provider.
 	// +optional

--- a/exp/api/v1alpha3/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1alpha3/azuremanagedmachinepool_webhook.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// log is for logging in this package.
+var azuremanagedmachinepoollog = logf.Log.WithName("azuremanagedmachinepool-resource")
+
+// +kubebuilder:webhook:path=/mutate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool,mutating=true,failurePolicy=fail,groups=exp.infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,verbs=create;update,versions=v1alpha3,name=azuremanagedmachinepool.kb.io
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) Default(client client.Client) {
+	azuremanagedmachinepoollog.Info("default", "name", r.Name)
+
+	if r.Labels == nil {
+		r.Labels = make(map[string]string)
+	}
+	r.Labels[LabelAgentPoolMode] = r.Spec.Mode
+}
+
+// +kubebuilder:webhook:verbs=update;delete,path=/validate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool,mutating=false,failurePolicy=fail,groups=exp.infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,versions=v1alpha3,name=azuremanagedmachinepool.kb.io
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) ValidateCreate(client client.Client) error {
+	azuremanagedmachinepoollog.Info("validate create", "name", r.Name)
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client client.Client) error {
+	old := oldRaw.(*AzureManagedMachinePool)
+	var allErrs field.ErrorList
+	if r.Spec.SKU != old.Spec.SKU {
+		allErrs = append(allErrs,
+			field.Invalid(
+				field.NewPath("Spec", "SKU"),
+				r.Spec.SKU,
+				"field is immutable"))
+	}
+
+	if old.Spec.OSDiskSizeGB != nil {
+		// Prevent OSDiskSizeGB modification if it was already set to some value
+		if *r.Spec.OSDiskSizeGB != *old.Spec.OSDiskSizeGB {
+			// changing the field is not allowed
+			allErrs = append(allErrs,
+				field.Invalid(
+					field.NewPath("Spec", "OSDiskSizeGB"),
+					*r.Spec.OSDiskSizeGB,
+					"field is immutable"))
+		}
+	}
+
+	if r.Spec.Mode != string(NodePoolModeSystem) && old.Spec.Mode == string(NodePoolModeSystem) {
+		// validate for last system node pool
+		if err := r.validateLastSystemNodePool(client); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("Spec", "Mode"),
+				r.Spec.Mode,
+				"Last system node pool cannot be mutated to user node pool"))
+		}
+	}
+
+	if len(allErrs) != 0 {
+		return apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedMachinePool").GroupKind(), r.Name, allErrs)
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
+func (r *AzureManagedMachinePool) ValidateDelete(client client.Client) error {
+	azuremanagedmachinepoollog.Info("validate delete", "name", r.Name)
+
+	if r.Spec.Mode != string(NodePoolModeSystem) {
+		return nil
+	}
+
+	return errors.Wrapf(r.validateLastSystemNodePool(client), "if the delete is triggered via owner MachinePool please refer to trouble shooting section in https://capz.sigs.k8s.io/topics/managedcluster.html")
+}
+
+// validateLastSystemNodePool is used to check if the existing system node pool is the last system node pool.
+// If it is a last system node pool it cannot be deleted or mutated to user node pool as AKS expects min 1 system node pool.
+func (r *AzureManagedMachinePool) validateLastSystemNodePool(cli client.Client) error {
+	ctx := context.Background()
+
+	// Fetch the Cluster.
+	clusterName, ok := r.Labels[clusterv1.ClusterLabelName]
+	if !ok {
+		return nil
+	}
+
+	ownerCluster := &clusterv1.Cluster{}
+	key := client.ObjectKey{
+		Namespace: r.Namespace,
+		Name:      clusterName,
+	}
+
+	if err := cli.Get(ctx, key, ownerCluster); err != nil {
+		if azure.ResourceNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if !ownerCluster.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	opt1 := client.InNamespace(r.Namespace)
+	opt2 := client.MatchingLabels(map[string]string{
+		clusterv1.ClusterLabelName: clusterName,
+		LabelAgentPoolMode:         string(NodePoolModeSystem),
+	})
+
+	ammpList := &AzureManagedMachinePoolList{}
+	if err := cli.List(ctx, ammpList, opt1, opt2); err != nil {
+		return err
+	}
+
+	if len(ammpList.Items) <= 1 {
+		return errors.New("AKS Cluster must have at least one system pool")
+	}
+	return nil
+}

--- a/exp/api/v1alpha3/azuremanagedmachinepool_webhook_test.go
+++ b/exp/api/v1alpha3/azuremanagedmachinepool_webhook_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestAzureManagedMachinePoolDefaultingWebhook(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Logf("Testing ammp defaulting webhook with mode system")
+	ammp := &AzureManagedMachinePool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fooName",
+		},
+		Spec: AzureManagedMachinePoolSpec{
+			Mode:         "System",
+			SKU:          "StandardD2S_V3",
+			OSDiskSizeGB: to.Int32Ptr(512),
+		},
+	}
+	var client client.Client
+	ammp.Default(client)
+	g.Expect(ammp.Labels).ToNot(BeNil())
+	val, ok := ammp.Labels[LabelAgentPoolMode]
+	g.Expect(ok).To(BeTrue())
+	g.Expect(val).To(Equal("System"))
+}
+
+func TestAzureManagedMachinePoolUpdatingWebhook(t *testing.T) {
+	g := NewWithT(t)
+
+	t.Logf("Testing ammp updating webhook with mode system")
+
+	tests := []struct {
+		name    string
+		new     *AzureManagedMachinePool
+		old     *AzureManagedMachinePool
+		wantErr bool
+	}{
+		{
+			name: "Cannot change SKU of the agentpool",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V4",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Cannot change OSDiskSizeGB of the agentpool",
+			new: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(512),
+				},
+			},
+			old: &AzureManagedMachinePool{
+				Spec: AzureManagedMachinePoolSpec{
+					Mode:         "System",
+					SKU:          "StandardD2S_V3",
+					OSDiskSizeGB: to.Int32Ptr(1024),
+				},
+			},
+			wantErr: true,
+		},
+	}
+	var client client.Client
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.new.ValidateUpdate(tc.old, client)
+			if tc.wantErr {
+				g.Expect(err).To(HaveOccurred())
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}

--- a/exp/api/v1alpha3/zz_generated.deepcopy.go
+++ b/exp/api/v1alpha3/zz_generated.deepcopy.go
@@ -436,7 +436,6 @@ func (in *AzureManagedControlPlaneSpec) DeepCopyInto(out *AzureManagedControlPla
 		*out = new(string)
 		**out = **in
 	}
-	out.DefaultPoolRef = in.DefaultPoolRef
 	if in.DNSServiceIP != nil {
 		in, out := &in.DNSServiceIP, &out.DNSServiceIP
 		*out = new(string)

--- a/exp/controllers/azuremanagedmachinepool_controller.go
+++ b/exp/controllers/azuremanagedmachinepool_controller.go
@@ -186,6 +186,14 @@ func (r *AzureManagedMachinePoolReconciler) Reconcile(req ctrl.Request) (_ ctrl.
 		return reconcile.Result{}, err
 	}
 
+	// For non-system node pools, we wait for the control plane to be
+	// initialized, otherwise Azure API will return an error for node pool
+	// CreateOrUpdate request.
+	if infraPool.Spec.Mode != string(infrav1exp.NodePoolModeSystem) && !controlPlane.Status.Initialized {
+		log.Info("AzureManagedControlPlane is not initialized")
+		return reconcile.Result{}, nil
+	}
+
 	// Create the scope.
 	mcpScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
 		Client:           r.Client,

--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -117,6 +117,7 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context, scope *s
 			scope.ControlPlane.Spec.VirtualNetwork.Name,
 			scope.ControlPlane.Spec.VirtualNetwork.Subnet.Name,
 		),
+		Mode: scope.InfraMachinePool.Spec.Mode,
 	}
 
 	if scope.InfraMachinePool.Spec.OSDiskSizeGB != nil {

--- a/exp/controllers/azuremangedcontrolplane_controller.go
+++ b/exp/controllers/azuremangedcontrolplane_controller.go
@@ -40,7 +40,6 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/scope"
-	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
@@ -140,61 +139,13 @@ func (r *AzureManagedControlPlaneReconciler) Reconcile(req ctrl.Request) (_ ctrl
 		return ctrl.Result{}, nil
 	}
 
-	// Handle deleted clusters
-	// needs to happen before trying to fetch the default pool to avoid circular deletion dependencies
-	if !azureControlPlane.DeletionTimestamp.IsZero() {
-		// Create the scope.
-		mcpScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
-			Client:       r.Client,
-			Logger:       log,
-			Cluster:      cluster,
-			ControlPlane: azureControlPlane,
-			PatchTarget:  azureControlPlane,
-		})
-		if err != nil {
-			return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)
-		}
-		defer func() {
-			if err := mcpScope.PatchObject(ctx); err != nil && reterr == nil {
-				reterr = err
-			}
-		}()
-		return r.reconcileDelete(ctx, mcpScope)
-	}
-
-	// fetch default pool
-	defaultPoolKey := client.ObjectKey{
-		Name:      azureControlPlane.Spec.DefaultPoolRef.Name,
-		Namespace: azureControlPlane.Namespace,
-	}
-	defaultPool := &infrav1exp.AzureManagedMachinePool{}
-	if err := r.Client.Get(ctx, defaultPoolKey, defaultPool); err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "failed to fetch default pool reference")
-	}
-
-	log = log.WithValues("azureManagedMachinePool", defaultPoolKey.Name)
-
-	// Fetch the owning MachinePool.
-	ownerPool, err := infracontroller.GetOwnerMachinePool(ctx, r.Client, defaultPool.ObjectMeta)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if ownerPool == nil {
-		log.Info("failed to fetch owner ref for default pool")
-		return reconcile.Result{}, nil
-	}
-
-	log = log.WithValues("machinePool", ownerPool.Name)
-
 	// Create the scope.
 	mcpScope, err := scope.NewManagedControlPlaneScope(scope.ManagedControlPlaneScopeParams{
-		Client:           r.Client,
-		Logger:           log,
-		Cluster:          cluster,
-		ControlPlane:     azureControlPlane,
-		MachinePool:      ownerPool,
-		InfraMachinePool: defaultPool,
-		PatchTarget:      azureControlPlane,
+		Client:       r.Client,
+		Logger:       log,
+		Cluster:      cluster,
+		ControlPlane: azureControlPlane,
+		PatchTarget:  azureControlPlane,
 	})
 	if err != nil {
 		return reconcile.Result{}, errors.Errorf("failed to create scope: %+v", err)
@@ -206,6 +157,11 @@ func (r *AzureManagedControlPlaneReconciler) Reconcile(req ctrl.Request) (_ ctrl
 			reterr = err
 		}
 	}()
+
+	// Handle deleted clusters
+	if !azureControlPlane.DeletionTimestamp.IsZero() {
+		return r.reconcileDelete(ctx, mcpScope)
+	}
 
 	// Handle non-deleted clusters
 	return r.reconcileNormal(ctx, mcpScope)

--- a/exp/controllers/azuremangedcontrolplane_reconciler.go
+++ b/exp/controllers/azuremangedcontrolplane_reconciler.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/managedclusters"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/subnets"
 	"sigs.k8s.io/cluster-api-provider-azure/cloud/services/virtualnetworks"
+	infracontroller "sigs.k8s.io/cluster-api-provider-azure/controllers"
 	infrav1exp "sigs.k8s.io/cluster-api-provider-azure/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -230,23 +231,58 @@ func (r *azureManagedControlPlaneReconciler) reconcileManagedCluster(ctx context
 	// We do this here because AKS will only let us mutate agent pools via managed
 	// clusters API at create time, not update.
 	if azure.ResourceNotFound(err) {
-		defaultPoolSpec := managedclusters.PoolSpec{
-			Name:         scope.InfraMachinePool.Name,
-			SKU:          scope.InfraMachinePool.Spec.SKU,
-			Replicas:     1,
-			OSDiskSizeGB: 0,
+		opt1 := client.InNamespace(scope.ControlPlane.Namespace)
+		opt2 := client.MatchingLabels(map[string]string{
+			infrav1exp.LabelAgentPoolMode: string(infrav1exp.NodePoolModeSystem),
+			clusterv1.ClusterLabelName:    scope.Cluster.Name,
+		})
+
+		ammpList := &infrav1exp.AzureManagedMachinePoolList{}
+
+		if err := r.kubeclient.List(ctx, ammpList, opt1, opt2); err != nil {
+			return err
 		}
 
-		// Set optional values
-		if scope.InfraMachinePool.Spec.OSDiskSizeGB != nil {
-			defaultPoolSpec.OSDiskSizeGB = *scope.InfraMachinePool.Spec.OSDiskSizeGB
+		if ammpList == nil || len(ammpList.Items) == 0 {
+			return errors.New("failed to fetch azuremanagedMachine pool with mode:System, require at least 1 system node pool")
 		}
-		if scope.MachinePool.Spec.Replicas != nil {
-			defaultPoolSpec.Replicas = *scope.MachinePool.Spec.Replicas
-		}
+		ammps := []managedclusters.PoolSpec{}
 
+		for _, pool := range ammpList.Items {
+			// Fetch the owning MachinePool.
+			ownerPool, err := infracontroller.GetOwnerMachinePool(ctx, r.kubeclient, pool.ObjectMeta)
+			if err != nil {
+				scope.Logger.Error(err, "failed to fetch owner ref for system pool: %s", pool.Name)
+				continue
+			}
+			if ownerPool == nil {
+				scope.Logger.Info("failed to fetch owner ref for system pool")
+				continue
+			}
+
+			ammp := managedclusters.PoolSpec{
+				Name:         pool.Name,
+				SKU:          pool.Spec.SKU,
+				Replicas:     1,
+				OSDiskSizeGB: 0,
+			}
+
+			// Set optional values
+			if pool.Spec.OSDiskSizeGB != nil {
+				ammp.OSDiskSizeGB = *pool.Spec.OSDiskSizeGB
+			}
+
+			if ownerPool.Spec.Replicas != nil {
+				ammp.Replicas = *ownerPool.Spec.Replicas
+			}
+
+			ammps = append(ammps, ammp)
+		}
+		if len(ammps) == 0 {
+			return errors.New("owner ref for system machine pools not ready")
+		}
 		// Add to cluster spec
-		managedClusterSpec.AgentPools = []managedclusters.PoolSpec{defaultPoolSpec}
+		managedClusterSpec.AgentPools = ammps
 	}
 
 	// Send to Azure for create/update.

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/pkg/ot"
 	"sigs.k8s.io/cluster-api-provider-azure/util/reconciler"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
+	"sigs.k8s.io/cluster-api-provider-azure/util/webhook"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
 )
 
@@ -371,6 +372,17 @@ func main() {
 				os.Exit(1)
 			}
 		}
+
+		if feature.Gates.Enabled(feature.AKS) {
+			hookServer := mgr.GetWebhookServer()
+			hookServer.Register("/mutate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool", webhook.NewMutatingWebhook(
+				&infrav1alpha3exp.AzureManagedMachinePool{}, mgr.GetClient(),
+			))
+			hookServer.Register("/validate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool", webhook.NewValidatingWebhook(
+				&infrav1alpha3exp.AzureManagedMachinePool{}, mgr.GetClient(),
+			))
+		}
+
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/spectro/generated/core-global.yaml
+++ b/spectro/generated/core-global.yaml
@@ -2827,15 +2827,6 @@ spec:
                 - host
                 - port
                 type: object
-              defaultPoolRef:
-                description: DefaultPoolRef is the specification for the default pool,
-                  without which an AKS cluster cannot be created.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
               dnsServiceIP:
                 description: DNSServiceIP is an IP address assigned to the Kubernetes
                   DNS service. It must be within the Kubernetes service address range
@@ -2910,7 +2901,6 @@ spec:
                 - name
                 type: object
             required:
-            - defaultPoolRef
             - location
             - nodeResourceGroupName
             - resourceGroupName
@@ -2988,6 +2978,13 @@ spec:
             description: AzureManagedMachinePoolSpec defines the desired state of
               AzureManagedMachinePool
             properties:
+              mode:
+                description: 'Mode - represents mode of an agent pool. Possible values
+                  include: System, User.'
+                enum:
+                - System
+                - User
+                type: string
               osDiskSizeGB:
                 description: OSDiskSizeGB is the disk size for every machine in this
                   agent pool. If you specify 0, it will apply the default osDisk size
@@ -3004,6 +3001,8 @@ spec:
                 description: SKU is the size of the VMs in the node pool.
                 type: string
             required:
+            - mode
+            - osDiskSizeGB
             - sku
             type: object
           status:
@@ -3127,6 +3126,267 @@ webhooks:
     - UPDATE
     resources:
     - azuremanagedcontrolplanes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: capz-webhook-service
+      namespace: capi-webhook-system
+      path: /mutate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool
+  failurePolicy: Fail
+  name: azuremanagedmachinepool.kb.io
+  rules:
+  - apiGroups:
+    - exp.infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azuremanagedmachinepools
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-azure
+  name: capz-manager-role-webhook
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - aadpodidentity.k8s.io
+  resources:
+  - azureidentities
+  - azureidentities/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - aadpodidentity.k8s.io
+  resources:
+  - azureidentitybindings
+  - azureidentitybindings/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - machines
+  - machines/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - exp.cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedcontrolplanes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedcontrolplanes/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedmachinepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - exp.infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremanagedmachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusteridentities
+  - azureclusteridentities/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azureclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachines/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - azuremachinetemplates
+  - azuremachinetemplates/status
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    cluster.x-k8s.io/provider: infrastructure-azure
+  name: capz-manager-rolebinding-webhook
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: capz-manager-role-webhook
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: capi-webhook-system
 ---
 apiVersion: v1
 kind: Service
@@ -3336,3 +3596,21 @@ webhooks:
     - UPDATE
     resources:
     - azuremanagedcontrolplanes
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: capz-webhook-service
+      namespace: capi-webhook-system
+      path: /validate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool
+  failurePolicy: Fail
+  name: azuremanagedmachinepool.kb.io
+  rules:
+  - apiGroups:
+    - exp.infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha3
+    operations:
+    - UPDATE
+    - DELETE
+    resources:
+    - azuremanagedmachinepools

--- a/templates/cluster-template-aks.yaml
+++ b/templates/cluster-template-aks.yaml
@@ -23,16 +23,12 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: default
 spec:
-  defaultPoolRef:
-    name: agentpool0
   location: ${AZURE_LOCATION}
-  resourceGroupName: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   nodeResourceGroupName: MC_${AZURE_RESOURCE_GROUP}_${CLUSTER_NAME}_${AZURE_LOCATION}
+  resourceGroupName: ${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   version: ${KUBERNETES_VERSION}
-  networkPlugin: kubenet
-      
 ---
 apiVersion: exp.infrastructure.cluster.x-k8s.io/v1alpha3
 kind: AzureManagedCluster
@@ -67,6 +63,7 @@ metadata:
   name: agentpool0
   namespace: default
 spec:
+  mode: System
   osDiskSizeGB: 512
   sku: ${AZURE_NODE_MACHINE_TYPE}
 ---
@@ -97,5 +94,6 @@ metadata:
   name: agentpool1
   namespace: default
 spec:
+  mode: User
   osDiskSizeGB: 1024
   sku: ${AZURE_NODE_MACHINE_TYPE}

--- a/templates/flavors/aks/cluster-template.yaml
+++ b/templates/flavors/aks/cluster-template.yaml
@@ -31,10 +31,9 @@ spec:
   subscriptionID: ${AZURE_SUBSCRIPTION_ID}
   resourceGroupName: "${AZURE_RESOURCE_GROUP:=${CLUSTER_NAME}}"
   location: "${AZURE_LOCATION}"
-  defaultPoolRef:
-    name: "agentpool0"
   sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
   version: "${KUBERNETES_VERSION}"
+  nodeResourceGroupName: MC_${AZURE_RESOURCE_GROUP}_${CLUSTER_NAME}_${AZURE_LOCATION}
 ---
 # Due to the nature of managed Kubernetes and the control plane implementation,
 # the infrastructure provider for AKS cluster is basically a no-op.
@@ -76,6 +75,7 @@ metadata:
 spec:
   osDiskSizeGB: 512
   sku: "${AZURE_NODE_MACHINE_TYPE}"
+  mode: System
 ---
 # Deploy a second agent pool with the same number of machines, but using potentially different infrastructure.
 apiVersion: exp.cluster.x-k8s.io/v1alpha3
@@ -106,3 +106,4 @@ metadata:
 spec:
   osDiskSizeGB: 1024
   sku: "${AZURE_NODE_MACHINE_TYPE}"
+  mode: User

--- a/util/webhook/mutator.go
+++ b/util/webhook/mutator.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Defaulter defines functions for setting defaults on resources.
+type Defaulter interface {
+	runtime.Object
+	Default(client client.Client)
+}
+
+// NewMutatingWebhook creates a new Webhook for Defaulting the provided type.
+func NewMutatingWebhook(defaulter Defaulter, client client.Client) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &mutatingHandler{
+			defaulter: defaulter,
+			Client:    client,
+		},
+	}
+}
+
+type mutatingHandler struct {
+	defaulter Defaulter
+	Client    client.Client
+	decoder   *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &mutatingHandler{}
+
+// InjectDecoder injects the decoder into a mutatingHandler.
+func (h *mutatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *mutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.defaulter == nil {
+		panic("defaulter should never be nil")
+	}
+
+	// Get the object in the request
+	obj := h.defaulter.DeepCopyObject().(Defaulter)
+	if err := h.decoder.Decode(req, obj); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Default the object
+	obj.Default(h.Client)
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Create the patch
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalled)
+}

--- a/util/webhook/validator.go
+++ b/util/webhook/validator.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"net/http"
+
+	"errors"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validator defines functions for validating an operation.
+type Validator interface {
+	runtime.Object
+	ValidateCreate(client client.Client) error
+	ValidateUpdate(old runtime.Object, client client.Client) error
+	ValidateDelete(client client.Client) error
+}
+
+// NewValidatingWebhook creates a new Webhook for validating the provided type.
+func NewValidatingWebhook(validator Validator, client client.Client) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &validatingHandler{
+			validator: validator,
+			Client:    client,
+		},
+	}
+}
+
+type validatingHandler struct {
+	validator Validator
+	Client    client.Client
+	decoder   *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &validatingHandler{}
+
+// InjectDecoder injects the decoder into a validatingHandler.
+func (h *validatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *validatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.validator == nil {
+		panic("validator should never be nil")
+	}
+
+	// Get the object in the request
+	obj := h.validator.DeepCopyObject().(Validator)
+	if req.Operation == admissionv1beta1.Create {
+		err := h.decoder.Decode(req, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err = obj.ValidateCreate(h.Client)
+		if err != nil {
+			var apiStatus apierrors.APIStatus
+			if errors.As(err, &apiStatus) {
+				return validationResponseFromStatus(false, apiStatus.Status())
+			}
+			return admission.Denied(err.Error())
+		}
+	}
+
+	if req.Operation == admissionv1beta1.Update {
+		oldObj := obj.DeepCopyObject()
+
+		err := h.decoder.DecodeRaw(req.Object, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		err = h.decoder.DecodeRaw(req.OldObject, oldObj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err = obj.ValidateUpdate(oldObj, h.Client)
+		if err != nil {
+			var apiStatus apierrors.APIStatus
+			if errors.As(err, &apiStatus) {
+				return validationResponseFromStatus(false, apiStatus.Status())
+			}
+			return admission.Denied(err.Error())
+		}
+	}
+
+	if req.Operation == admissionv1beta1.Delete {
+		// In reference to PR: https://github.com/kubernetes/kubernetes/pull/76346
+		// OldObject contains the object being deleted
+		err := h.decoder.DecodeRaw(req.OldObject, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		err = obj.ValidateDelete(h.Client)
+		if err != nil {
+			var apiStatus apierrors.APIStatus
+			if errors.As(err, &apiStatus) {
+				return validationResponseFromStatus(false, apiStatus.Status())
+			}
+			return admission.Denied(err.Error())
+		}
+	}
+
+	return admission.Allowed("")
+}
+
+func validationResponseFromStatus(allowed bool, status metav1.Status) admission.Response {
+	return admission.Response{
+		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+			Allowed: allowed,
+			Result:  &status,
+		},
+	}
+}


### PR DESCRIPTION
This PR introduces spec Mode in azuremanagedmachinepool object and removes spec defaultPoolRef in azuremanagedcontrolplane object.

It is a fork from the upstream PR which has the following changes

system node pool will be of type system and not user.
added mode in the azuremannagedmachinepool api to set the mode of azure agent pools
removed defaultPoolRef from azuremanagedcontrolplane api. (provides more flexibility to manage system node pools.)
validation for deletion of last system node pool is handled in the webhook.
a util for custom webhook which parses in a client object.