### PR TITLE
removed delete validation in azuremanagedmachinepool 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ STAGING_REGISTRY := gcr.io/k8s-staging-cluster-api-azure
 PROD_REGISTRY := us.gcr.io/k8s-artifacts-prod/cluster-api-azure
 IMAGE_NAME ?= cluster-api-azure-controller
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
-TAG ?= spectro-master-20210730
+TAG ?= dev
 ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 

--- a/cloud/services/virtualnetworks/virtualnetworks.go
+++ b/cloud/services/virtualnetworks/virtualnetworks.go
@@ -113,13 +113,20 @@ func (s *Service) Delete(ctx context.Context) error {
 	defer span.End()
 
 	vnetSpec := s.Scope.VNetSpec()
-	if !s.Scope.Vnet().IsManaged(s.Scope.ClusterName()) {
+
+	existingVnet, err := s.getExisting(ctx, vnetSpec)
+	if azure.ResourceNotFound(err) {
+		// vnet does not exist might be deleted return
+		return nil
+	}
+
+	if !existingVnet.IsManaged(s.Scope.ClusterName()) {
 		s.Scope.V(4).Info("Skipping VNet deletion in custom vnet mode")
 		return nil
 	}
 
 	s.Scope.V(2).Info("deleting VNet", "VNet", vnetSpec.Name)
-	err := s.Client.Delete(ctx, vnetSpec.ResourceGroup, vnetSpec.Name)
+	err = s.Client.Delete(ctx, vnetSpec.ResourceGroup, vnetSpec.Name)
 	if err != nil {
 		if azure.ResourceGroupNotFound(err) || azure.ResourceNotFound(err) {
 			return nil

--- a/cloud/services/virtualnetworks/virtualnetworks_test.go
+++ b/cloud/services/virtualnetworks/virtualnetworks_test.go
@@ -294,6 +294,21 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "vnet-exists",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
+				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
+					Return(network.VirtualNetwork{
+						ID:   to.StringPtr("azure/fake/id"),
+						Name: to.StringPtr("vnet-exists"),
+						VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
+							AddressSpace: &network.AddressSpace{
+								AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/8"}),
+							},
+						},
+						Tags: map[string]*string{
+							"Name": to.StringPtr("vnet-exists"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_fake-cluster": to.StringPtr("owned"),
+							"sigs.k8s.io_cluster-api-provider-azure_role":                 to.StringPtr("common"),
+						},
+					}, nil)
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists")
 			},
 		},
@@ -315,8 +330,8 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "vnet-exists",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
-				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
-					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
+				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
+					Return(network.VirtualNetwork{}, autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 404}, "Not found"))
 			},
 		},
 		{
@@ -333,6 +348,19 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "my-vnet",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
+				m.Get(gomockinternal.AContext(), "my-rg", "my-vnet").
+					Return(network.VirtualNetwork{
+						ID:   to.StringPtr("azure/custom-vnet/id"),
+						Name: to.StringPtr("my-vnet"),
+						VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
+							AddressSpace: &network.AddressSpace{
+								AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/16"}),
+							},
+						},
+						Tags: map[string]*string{
+							"Name": to.StringPtr("my-vnet"),
+						},
+					}, nil)
 			},
 		},
 		{
@@ -353,6 +381,21 @@ func TestDeleteVnet(t *testing.T) {
 					Name:          "vnet-exists",
 					CIDRs:         []string{"10.0.0.0/16"},
 				})
+				m.Get(gomockinternal.AContext(), "my-rg", "vnet-exists").
+					Return(network.VirtualNetwork{
+						ID:   to.StringPtr("azure/fake/id"),
+						Name: to.StringPtr("vnet-exists"),
+						VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
+							AddressSpace: &network.AddressSpace{
+								AddressPrefixes: to.StringSlicePtr([]string{"10.0.0.0/8"}),
+							},
+						},
+						Tags: map[string]*string{
+							"Name": to.StringPtr("vnet-exists"),
+							"sigs.k8s.io_cluster-api-provider-azure_cluster_fake-cluster": to.StringPtr("owned"),
+							"sigs.k8s.io_cluster-api-provider-azure_role":                 to.StringPtr("common"),
+						},
+					}, nil)
 				m.Delete(gomockinternal.AContext(), "my-rg", "vnet-exists").
 					Return(autorest.NewErrorWithResponse("", "", &http.Response{StatusCode: 500}, "Internal Honk Server"))
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -201,6 +201,5 @@ webhooks:
     - v1alpha3
     operations:
     - UPDATE
-    - DELETE
     resources:
     - azuremanagedmachinepools

--- a/exp/api/v1alpha3/azuremanagedmachinepool_webhook.go
+++ b/exp/api/v1alpha3/azuremanagedmachinepool_webhook.go
@@ -17,15 +17,9 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"context"
-
-	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-
-	azure "sigs.k8s.io/cluster-api-provider-azure/cloud"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -46,7 +40,7 @@ func (r *AzureManagedMachinePool) Default(client client.Client) {
 	r.Labels[LabelAgentPoolMode] = r.Spec.Mode
 }
 
-// +kubebuilder:webhook:verbs=update;delete,path=/validate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool,mutating=false,failurePolicy=fail,groups=exp.infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,versions=v1alpha3,name=azuremanagedmachinepool.kb.io
+// +kubebuilder:webhook:verbs=update,path=/validate-exp-infrastructure-cluster-x-k8s-io-v1alpha3-azuremanagedmachinepool,mutating=false,failurePolicy=fail,groups=exp.infrastructure.cluster.x-k8s.io,resources=azuremanagedmachinepools,versions=v1alpha3,name=azuremanagedmachinepool.kb.io
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedMachinePool) ValidateCreate(client client.Client) error {
@@ -77,76 +71,14 @@ func (r *AzureManagedMachinePool) ValidateUpdate(oldRaw runtime.Object, client c
 					"field is immutable"))
 		}
 	}
-
-	if r.Spec.Mode != string(NodePoolModeSystem) && old.Spec.Mode == string(NodePoolModeSystem) {
-		// validate for last system node pool
-		if err := r.validateLastSystemNodePool(client); err != nil {
-			allErrs = append(allErrs, field.Invalid(
-				field.NewPath("Spec", "Mode"),
-				r.Spec.Mode,
-				"Last system node pool cannot be mutated to user node pool"))
-		}
-	}
-
 	if len(allErrs) != 0 {
 		return apierrors.NewInvalid(GroupVersion.WithKind("AzureManagedMachinePool").GroupKind(), r.Name, allErrs)
 	}
-
 	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type.
 func (r *AzureManagedMachinePool) ValidateDelete(client client.Client) error {
 	azuremanagedmachinepoollog.Info("validate delete", "name", r.Name)
-
-	if r.Spec.Mode != string(NodePoolModeSystem) {
-		return nil
-	}
-
-	return errors.Wrapf(r.validateLastSystemNodePool(client), "if the delete is triggered via owner MachinePool please refer to trouble shooting section in https://capz.sigs.k8s.io/topics/managedcluster.html")
-}
-
-// validateLastSystemNodePool is used to check if the existing system node pool is the last system node pool.
-// If it is a last system node pool it cannot be deleted or mutated to user node pool as AKS expects min 1 system node pool.
-func (r *AzureManagedMachinePool) validateLastSystemNodePool(cli client.Client) error {
-	ctx := context.Background()
-
-	// Fetch the Cluster.
-	clusterName, ok := r.Labels[clusterv1.ClusterLabelName]
-	if !ok {
-		return nil
-	}
-
-	ownerCluster := &clusterv1.Cluster{}
-	key := client.ObjectKey{
-		Namespace: r.Namespace,
-		Name:      clusterName,
-	}
-
-	if err := cli.Get(ctx, key, ownerCluster); err != nil {
-		if azure.ResourceNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	if !ownerCluster.DeletionTimestamp.IsZero() {
-		return nil
-	}
-
-	opt1 := client.InNamespace(r.Namespace)
-	opt2 := client.MatchingLabels(map[string]string{
-		clusterv1.ClusterLabelName: clusterName,
-		LabelAgentPoolMode:         string(NodePoolModeSystem),
-	})
-
-	ammpList := &AzureManagedMachinePoolList{}
-	if err := cli.List(ctx, ammpList, opt1, opt2); err != nil {
-		return err
-	}
-
-	if len(ammpList.Items) <= 1 {
-		return errors.New("AKS Cluster must have at least one system pool")
-	}
 	return nil
 }

--- a/spectro/generated/core-base.yaml
+++ b/spectro/generated/core-base.yaml
@@ -555,7 +555,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller:latest
+        image: gcr.io/spectro-images-public/release/cluster-api-azure/cluster-api-azure-controller:spectro-master-20210804
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/spectro/generated/core-global.yaml
+++ b/spectro/generated/core-global.yaml
@@ -3454,7 +3454,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller:latest
+        image: gcr.io/spectro-images-public/release/cluster-api-azure/cluster-api-azure-controller:spectro-master-20210804
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -3611,6 +3611,5 @@ webhooks:
     - v1alpha3
     operations:
     - UPDATE
-    - DELETE
     resources:
     - azuremanagedmachinepools


### PR DESCRIPTION

 <!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md). -->

 <!-- Please label this pull request according to what type of issue you are addressing (see ../CONTRIBUTING.md) -->
**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind other
-->

**What this PR does / why we need it**:
During pivot the managedmachinepool webhook will prevent the mp from deletion as it will be the last system node pool. 
It is an ideal scenario when we use clusterctl, capi and capz. This is not required when we manage clusters using spectro because palette makes a validation check before deleting the mp when the workload clusters are removed from azurecloudconfig. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: Did not want to play around/modify the existing pivot logic in palette as it is critical and in case of any issues will break for all the providers.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
