### PR TITLE
use aks-managed-poolName also for vmss match

### DIFF
--- a/exp/controllers/azuremanagedmachinepool_reconciler.go
+++ b/exp/controllers/azuremanagedmachinepool_reconciler.go
@@ -107,6 +107,11 @@ func (s *azureManagedMachinePoolService) Reconcile(ctx context.Context) error {
 			match = &ss
 			break
 		}
+
+		if ss.Tags["aks-managed-poolName"] != nil && *ss.Tags["aks-managed-poolName"] == agentPoolName {
+			match = &ss
+			break
+		}
 	}
 
 	if match == nil {


### PR DESCRIPTION
cherry-pick [commit](https://github.com/kubernetes-sigs/cluster-api-provider-azure/commit/aed75ffd6818dfc4879e244d62d0838e4e6efbd7) 