### PR TITLE
Revert "PEM-483: palette changes to input privatednszone"

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -164,8 +164,8 @@ func GeneratePrivateDNSZoneName(clusterName string) string {
 }
 
 // GeneratePrivateFQDN generates the FQDN for a private API Server based on the private DNS zone name.
-func GeneratePrivateFQDN(zoneName, clusterName string) string {
-	return fmt.Sprintf("%s.%s.%s", PrivateAPIServerHostname, clusterName, zoneName)
+func GeneratePrivateFQDN(zoneName string) string {
+	return fmt.Sprintf("%s.%s", PrivateAPIServerHostname, zoneName)
 }
 
 // GenerateVNetLinkName generates the name of a virtual network link name based on the vnet name.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -441,7 +441,7 @@ func (s *ClusterScope) PrivateDNSSpec() (zoneSpec azure.ResourceSpecGetter, link
 		records := make([]azure.ResourceSpecGetter, 1)
 		records[0] = privatedns.RecordSpec{
 			Record: infrav1.AddressRecord{
-				Hostname: s.getHostName(),
+				Hostname: azure.PrivateAPIServerHostname,
 				IP:       s.APIServerPrivateIP(),
 			},
 			ZoneName:      s.GetPrivateDNSZoneName(),
@@ -452,13 +452,6 @@ func (s *ClusterScope) PrivateDNSSpec() (zoneSpec azure.ResourceSpecGetter, link
 	}
 
 	return nil, nil, nil
-}
-
-func (s *ClusterScope) getHostName() string {
-	if s.AzureCluster.Spec.NetworkSpec.PrivateDNSZoneName != "" {
-		return fmt.Sprintf("%s.%s", azure.PrivateAPIServerHostname, s.AzureCluster.Name)
-	}
-	return azure.PrivateAPIServerHostname
 }
 
 // IsAzureBastionEnabled returns true if the azure bastion is enabled.
@@ -779,7 +772,7 @@ func (s *ClusterScope) APIServerPort() int32 {
 // APIServerHost returns the hostname used to reach the API server.
 func (s *ClusterScope) APIServerHost() string {
 	if s.IsAPIServerPrivate() {
-		return azure.GeneratePrivateFQDN(s.GetPrivateDNSZoneName(), s.AzureCluster.Name)
+		return azure.GeneratePrivateFQDN(s.GetPrivateDNSZoneName())
 	}
 	return s.APIServerPublicIP().DNSName
 }


### PR DESCRIPTION
Reverts spectrocloud/cluster-api-provider-azure#56