### PR TITLE
fix: reuse global TracerProvider

### DIFF
--- a/azure/defaults.go
+++ b/azure/defaults.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -28,8 +27,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5"
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
+	"go.opentelemetry.io/otel"
 
-	"sigs.k8s.io/cluster-api-provider-azure/pkg/ot"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 	"sigs.k8s.io/cluster-api-provider-azure/version"
 )
@@ -383,11 +382,7 @@ func ARMClientOptions(azureEnvironment string, extraPolicies ...policy.Policy) (
 	opts.PerCallPolicies = append(opts.PerCallPolicies, extraPolicies...)
 	opts.Retry.MaxRetries = -1 // Less than zero means one try and no retries.
 
-	otelTP, err := ot.OTLPTracerProvider(context.TODO())
-	if err != nil {
-		return nil, err
-	}
-	opts.TracingProvider = azotel.NewTracingProvider(otelTP, nil)
+	opts.TracingProvider = azotel.NewTracingProvider(otel.GetTracerProvider(), nil)
 
 	return opts, nil
 }

--- a/azure/scope/identity.go
+++ b/azure/scope/identity.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,7 +34,6 @@ import (
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
-	"sigs.k8s.io/cluster-api-provider-azure/pkg/ot"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
@@ -89,11 +89,7 @@ func (p *AzureCredentialsProvider) GetTokenCredential(ctx context.Context, resou
 	var authErr error
 	var cred azcore.TokenCredential
 
-	otelTP, err := ot.OTLPTracerProvider(ctx)
-	if err != nil {
-		return nil, err
-	}
-	tracingProvider := azotel.NewTracingProvider(otelTP, nil)
+	tracingProvider := azotel.NewTracingProvider(otel.GetTracerProvider(), nil)
 
 	switch p.Identity.Spec.Type {
 	case infrav1.WorkloadIdentity:
@@ -133,6 +129,7 @@ func (p *AzureCredentialsProvider) GetTokenCredential(ctx context.Context, resou
 	case infrav1.ServicePrincipalCertificate:
 		var certsContent []byte
 		if p.Identity.Spec.CertPath != "" {
+			var err error
 			certsContent, err = os.ReadFile(p.Identity.Spec.CertPath)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to read certificate file")

--- a/controllers/aso_credential_cache.go
+++ b/controllers/aso_credential_cache.go
@@ -26,12 +26,12 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/tracing/azotel"
 	asoannotations "github.com/Azure/azure-service-operator/v2/pkg/common/annotations"
 	"github.com/Azure/azure-service-operator/v2/pkg/common/config"
+	"go.opentelemetry.io/otel"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/cluster-api-provider-azure/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/scope"
-	"sigs.k8s.io/cluster-api-provider-azure/pkg/ot"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
 
@@ -98,13 +98,8 @@ func (c *asoCredentialCache) clientOptsForASOResource(ctx context.Context, obj c
 		return azcore.ClientOptions{}, err
 	}
 
-	otelTP, err := ot.OTLPTracerProvider(ctx)
-	if err != nil {
-		return azcore.ClientOptions{}, err
-	}
-
 	opts := azcore.ClientOptions{
-		TracingProvider: azotel.NewTracingProvider(otelTP, nil),
+		TracingProvider: azotel.NewTracingProvider(otel.GetTracerProvider(), nil),
 		Cloud: cloud.Configuration{
 			ActiveDirectoryAuthorityHost: string(secret.Data[config.AzureAuthorityHost]),
 		},

--- a/pkg/ot/traces.go
+++ b/pkg/ot/traces.go
@@ -35,7 +35,7 @@ import (
 
 // RegisterTracing enables code tracing via OpenTelemetry.
 func RegisterTracing(ctx context.Context, log logr.Logger) error {
-	tp, err := OTLPTracerProvider(ctx)
+	tp, err := otlpTracerProvider(ctx)
 	if err != nil {
 		return err
 	}
@@ -54,8 +54,8 @@ func RegisterTracing(ctx context.Context, log logr.Logger) error {
 	return nil
 }
 
-// OTLPTracerProvider initializes an OTLP exporter and configures the corresponding tracer provider.
-func OTLPTracerProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
+// otlpTracerProvider initializes an OTLP exporter and configures the corresponding tracer provider.
+func otlpTracerProvider(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	res, err := resource.New(ctx,
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("capz"),


### PR DESCRIPTION
Upstream cherry-pick https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/5540