### PR TITLE
Adding support for ussec to eastus2 location mapping for azuresecret …

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualnetworks"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/vnetpeerings"
 	"sigs.k8s.io/cluster-api-provider-azure/feature"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/futures"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -884,7 +885,7 @@ func (s *ClusterScope) Namespace() string {
 
 // Location returns the cluster location.
 func (s *ClusterScope) Location() string {
-	return s.AzureCluster.Spec.Location
+	return azureutil.NormalizeAzureRegion(s.AzureCluster.Spec.Location)
 }
 
 // AvailabilitySetEnabled informs machines that they should be part of an Availability Set.

--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -885,7 +885,16 @@ func (s *ClusterScope) Namespace() string {
 
 // Location returns the cluster location.
 func (s *ClusterScope) Location() string {
-	return azureutil.NormalizeAzureRegion(s.AzureCluster.Spec.Location)
+	// Only apply region normalization if both conditions are met:
+	// 1. We're in AzureUSSecretCloud environment AND
+	// 2. Resource manager endpoint contains .scombine.scloud suffix
+	if s.AzureCluster.Spec.AzureEnvironment == "AzureUSSecretCloud" &&
+		strings.Contains(s.ResourceManagerEndpoint, ".scombine.scloud") {
+		return azureutil.NormalizeAzureRegion(s.AzureCluster.Spec.Location)
+	}
+
+	// Otherwise, return the original location unchanged
+	return s.AzureCluster.Spec.Location
 }
 
 // AvailabilitySetEnabled informs machines that they should be part of an Availability Set.

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -210,7 +210,7 @@ func (m *MachinePoolScope) ScaleSetSpec(ctx context.Context) azure.ResourceSpecG
 		NetworkInterfaces:            m.AzureMachinePool.Spec.Template.NetworkInterfaces,
 		IPv6Enabled:                  m.IsIPv6Enabled(),
 		OrchestrationMode:            m.AzureMachinePool.Spec.OrchestrationMode,
-		Location:                     azureutil.NormalizeAzureRegion(m.AzureMachinePool.Spec.Location),
+		Location:                     m.Location(),
 		SubscriptionID:               m.SubscriptionID(),
 		HasReplicasExternallyManaged: m.HasReplicasExternallyManaged(ctx),
 		ClusterName:                  m.ClusterName(),
@@ -237,6 +237,20 @@ func (m *MachinePoolScope) ScaleSetSpec(ctx context.Context) azure.ResourceSpecG
 	}
 
 	return spec
+}
+
+// Location returns the machine pool location.
+func (m *MachinePoolScope) Location() string {
+	// Only apply region normalization if both conditions are met:
+	// 1. We're in AzureUSSecretCloud environment AND
+	// 2. Resource manager endpoint contains .scombine.scloud suffix
+	if m.CloudEnvironment() == "AzureUSSecretCloud" &&
+		strings.Contains(m.BaseURI(), ".scombine.scloud") {
+		return azureutil.NormalizeAzureRegion(m.AzureMachinePool.Spec.Location)
+	}
+
+	// Otherwise, return the original location unchanged
+	return m.AzureMachinePool.Spec.Location
 }
 
 // Name returns the Azure Machine Pool Name.

--- a/azure/scope/machinepool.go
+++ b/azure/scope/machinepool.go
@@ -210,7 +210,7 @@ func (m *MachinePoolScope) ScaleSetSpec(ctx context.Context) azure.ResourceSpecG
 		NetworkInterfaces:            m.AzureMachinePool.Spec.Template.NetworkInterfaces,
 		IPv6Enabled:                  m.IsIPv6Enabled(),
 		OrchestrationMode:            m.AzureMachinePool.Spec.OrchestrationMode,
-		Location:                     m.AzureMachinePool.Spec.Location,
+		Location:                     azureutil.NormalizeAzureRegion(m.AzureMachinePool.Spec.Location),
 		SubscriptionID:               m.SubscriptionID(),
 		HasReplicasExternallyManaged: m.HasReplicasExternallyManaged(ctx),
 		ClusterName:                  m.ClusterName(),

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/privateendpoints"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/subnets"
 	"sigs.k8s.io/cluster-api-provider-azure/azure/services/virtualnetworks"
+	azureutil "sigs.k8s.io/cluster-api-provider-azure/util/azure"
 	"sigs.k8s.io/cluster-api-provider-azure/util/futures"
 	"sigs.k8s.io/cluster-api-provider-azure/util/tele"
 )
@@ -183,7 +184,7 @@ func (s *ManagedControlPlaneScope) Location() string {
 	if s.ControlPlane == nil {
 		return ""
 	}
-	return s.ControlPlane.Spec.Location
+	return azureutil.NormalizeAzureRegion(s.ControlPlane.Spec.Location)
 }
 
 // ExtendedLocation has not been implemented for AzureManagedControlPlane.
@@ -592,7 +593,7 @@ func (s *ManagedControlPlaneScope) ManagedClusterSpec() azure.ASOResourceSpecGet
 		ResourceGroup:     s.ControlPlane.Spec.ResourceGroupName,
 		NodeResourceGroup: s.ControlPlane.Spec.NodeResourceGroupName,
 		ClusterName:       s.ClusterName(),
-		Location:          s.ControlPlane.Spec.Location,
+		Location:          s.Location(),
 		Tags:              s.ControlPlane.Spec.AdditionalTags,
 		Version:           strings.TrimPrefix(s.ControlPlane.Spec.Version, "v"),
 		DNSServiceIP:      s.ControlPlane.Spec.DNSServiceIP,

--- a/azure/scope/managedcontrolplane.go
+++ b/azure/scope/managedcontrolplane.go
@@ -184,7 +184,17 @@ func (s *ManagedControlPlaneScope) Location() string {
 	if s.ControlPlane == nil {
 		return ""
 	}
-	return azureutil.NormalizeAzureRegion(s.ControlPlane.Spec.Location)
+
+	// Only apply region normalization if both conditions are met:
+	// 1. We're in AzureUSSecretCloud environment AND
+	// 2. Resource manager endpoint contains .scombine.scloud suffix
+	if s.ControlPlane.Spec.AzureEnvironment == "AzureUSSecretCloud" &&
+		strings.Contains(s.ResourceManagerEndpoint, ".scombine.scloud") {
+		return azureutil.NormalizeAzureRegion(s.ControlPlane.Spec.Location)
+	}
+
+	// Otherwise, return the original location unchanged
+	return s.ControlPlane.Spec.Location
 }
 
 // ExtendedLocation has not been implemented for AzureManagedControlPlane.

--- a/util/azure/azure.go
+++ b/util/azure/azure.go
@@ -102,8 +102,6 @@ var regionMapping = map[string]string{
 
 // NormalizeAzureRegion translates custom region names to standard Azure region names.
 // If the region is not in the mapping, it returns the original region name.
-// This function is useful for environments like Azure Stack Edge, Azure Government,
-// or other deployments where custom region names are used.
 func NormalizeAzureRegion(region string) string {
 	if normalizedRegion, exists := regionMapping[region]; exists {
 		return normalizedRegion

--- a/util/azure/azure.go
+++ b/util/azure/azure.go
@@ -91,3 +91,22 @@ func ConvertResourceGroupNameToLower(resourceID string) (string, error) {
 	resourceGroup := matches[1]
 	return strings.Replace(resourceID, resourceGroup, strings.ToLower(resourceGroup), 1), nil
 }
+
+// regionMapping contains mappings from custom region names to standard Azure region names.
+// This is useful for environments where custom region names are used that need to be
+// translated to standard Azure region names for API calls.
+var regionMapping = map[string]string{
+	"ussec": "eastus2",
+	// Add other custom region mappings as needed
+}
+
+// NormalizeAzureRegion translates custom region names to standard Azure region names.
+// If the region is not in the mapping, it returns the original region name.
+// This function is useful for environments like Azure Stack Edge, Azure Government,
+// or other deployments where custom region names are used.
+func NormalizeAzureRegion(region string) string {
+	if normalizedRegion, exists := regionMapping[region]; exists {
+		return normalizedRegion
+	}
+	return region
+}

--- a/util/azure/azure_test.go
+++ b/util/azure/azure_test.go
@@ -269,3 +269,8 @@ func TestNormalizeAzureRegion(t *testing.T) {
 		})
 	}
 }
+
+// Note: The conditional logic for when to apply region normalization is now
+// handled in the individual Location() methods in each scope, based on:
+// 1. AzureEnvironment == "AzureUSSecretCloud"
+// 2. ResourceManagerEndpoint contains ".scombine.scloud"

--- a/util/azure/azure_test.go
+++ b/util/azure/azure_test.go
@@ -232,3 +232,40 @@ func TestConvertResourceGroupNameToLower(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeAzureRegion(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputRegion    string
+		expectedRegion string
+	}{
+		{
+			name:           "mapped region - ussec to eastus2",
+			inputRegion:    "ussec",
+			expectedRegion: "eastus2",
+		},
+		{
+			name:           "unmapped region - standard region passes through",
+			inputRegion:    "westus",
+			expectedRegion: "westus",
+		},
+		{
+			name:           "unmapped region - non-standard region passes through",
+			inputRegion:    "customregion",
+			expectedRegion: "customregion",
+		},
+		{
+			name:           "empty region",
+			inputRegion:    "",
+			expectedRegion: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := NormalizeAzureRegion(tt.inputRegion)
+			g.Expect(result).To(Equal(tt.expectedRegion))
+		})
+	}
+}


### PR DESCRIPTION
This is the minor fix for azure secret cloud emulation env provisioning. The Sequioa team made a wrapper on location name from eastus2 to ussec, therefore we need a re-mapping to make Azure API call working. Same logic will apply in palette, to make azure.json get necessary changes.