### PR TITLE
[PCP-5127] Fix panic for fully-private clusters

### DIFF
--- a/azure/scope/cluster.go
+++ b/azure/scope/cluster.go
@@ -174,7 +174,7 @@ func (s *ClusterScope) PublicIPSpecs() []azure.ResourceSpecGetter {
 				IPTags:           ip.PublicIP.IPTags,
 			})
 		}
-	} else {
+	} else if !s.IsAPIServerPrivate() || s.AzureCluster.Spec.AzureEnvironment == azure.AzSecretCloudName {
 		if s.ControlPlaneEnabled() {
 			controlPlaneOutboundIPSpecs = []azure.ResourceSpecGetter{
 				&publicips.PublicIPSpec{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
When creating a cluster with fully-private addressing in Palette, AzureCluster reconciler panics. This is a regression introduced in https://github.com/spectrocloud/cluster-api-provider-azure/pull/117 where the codepath for creating control plane outbound IPs gets executed even when the API server is private. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://spectrocloud.atlassian.net/browse/PCP-5127. 

**Special notes for your reviewer**:
<!-- Refer to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/docs/book/src/developers/releasing.md#release-support for more information about which changes are eligible for backport -->

- [ ] cherry-pick candidate

**TODOs**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR. -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes panic for fully-private clusters
```
